### PR TITLE
Style weapons and spells pages like items

### DIFF
--- a/CampaignManager.Web/Components/Features/Spells/Components/SpellTableRow.razor
+++ b/CampaignManager.Web/Components/Features/Spells/Components/SpellTableRow.razor
@@ -1,81 +1,77 @@
 @using CampaignManager.Web.Components.Features.Spells.Model
+@using CampaignManager.Web.Components.Shared
 @namespace CampaignManager.Web.Components.Features.Spells.Components
 
-<tr class="@(IsExpanded ? "bg-primary-50" : "hover:bg-gray-50") transition-all duration-200 cursor-pointer active:bg-gray-100"
+<tr class="@(IsExpanded ? "bg-gray-50" : "hover:bg-gray-50") transition-colors cursor-pointer"
     @onclick="ToggleExpand">
-    <td class="px-4 sm:px-6 py-4 font-semibold text-gray-900">
-        <div class="flex items-center gap-3">
-            <button type="button"
-                    class="w-8 h-8 flex items-center justify-center text-primary-600 hover:text-primary-800 hover:bg-primary-50 rounded-lg transition-colors"
-                    @onclick:stopPropagation="true"
-                    @onclick="ToggleExpand">
-                <i class="fas @(IsExpanded ? "fa-chevron-up" : "fa-chevron-down")"></i>
-            </button>
-            <span>@Spell.Name</span>
-        </div>
-    </td>
-    <td class="px-4 sm:px-6 py-4">
+    <td class="px-4 py-3 font-medium text-gray-900">@Spell.Name</td>
+    <td class="px-4 py-3">
         @if (!string.IsNullOrWhiteSpace(Spell.SpellType))
         {
-            <Badge Variant="primary">
+            <Badge Variant="primary" Size="sm" Rounded="md" WithBorder="false">
                 @Spell.SpellType
             </Badge>
         }
         else
         {
-            <span class="text-gray-400 text-sm">—</span>
+            <span class="text-gray-400 text-xs">—</span>
         }
     </td>
-    <td class="px-4 sm:px-6 py-4 text-gray-700 font-medium">@(!string.IsNullOrWhiteSpace(Spell.Cost) ? Spell.Cost : "—")</td>
-    <td class="px-4 sm:px-6 py-4 text-gray-700 font-medium">@(!string.IsNullOrWhiteSpace(Spell.CastingTime) ? Spell.CastingTime : "—")</td>
-    <td class="px-4 sm:px-6 py-4 text-center" @onclick:stopPropagation="true">
-        <div class="flex flex-col sm:flex-row gap-2 justify-center">
-            <button @onclick="() => OnEdit.InvokeAsync(Spell)"
-                    class="min-h-[44px] px-4 py-2 text-primary-600 hover:text-primary-800 bg-primary-50 hover:bg-primary-100 rounded-lg text-sm font-semibold flex items-center justify-center gap-2 transition-all duration-200 border border-primary-200">
-                <i class="fas fa-edit"></i>
-                <span>Изменить</span>
-            </button>
-            <button @onclick="() => OnDelete.InvokeAsync(Spell)"
-                    class="min-h-[44px] px-4 py-2 text-error-600 hover:text-error-800 bg-error-50 hover:bg-error-100 rounded-lg text-sm font-semibold flex items-center justify-center gap-2 transition-all duration-200 border border-error-200">
-                <i class="fas fa-trash-alt"></i>
-                <span>Удалить</span>
-            </button>
+    <td class="px-4 py-3 text-gray-700">@(!string.IsNullOrWhiteSpace(Spell.Cost) ? Spell.Cost : "—")</td>
+    <td class="px-4 py-3 text-gray-700">@(!string.IsNullOrWhiteSpace(Spell.CastingTime) ? Spell.CastingTime : "—")</td>
+    <td class="px-4 py-3 text-center" @onclick:stopPropagation="true">
+        <div class="flex gap-1 justify-center">
+            <Button OnClick="() => OnEdit.InvokeAsync(Spell)"
+                    Variant="outline-primary"
+                    Size="sm"
+                    Icon="fa-edit"
+                    AdditionalClasses="text-xs shadow-none border-0">
+                Изменить
+            </Button>
+            <Button OnClick="() => OnDelete.InvokeAsync(Spell)"
+                    Variant="outline-error"
+                    Size="sm"
+                    Icon="fa-trash-alt"
+                    AdditionalClasses="text-xs shadow-none border-0">
+                Удалить
+            </Button>
         </div>
     </td>
 </tr>
 
 @if (IsExpanded)
 {
-    <tr class="bg-gradient-to-r from-gray-50 to-white border-t-2 border-primary-200">
-        <td colspan="5" class="px-4 sm:px-6 py-6">
-            <div class="bg-white rounded-xl p-6 shadow-inner border-2 border-gray-100 space-y-6">
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div class="space-y-1">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Название</h5>
-                        <p class="text-base font-medium text-gray-900">@Spell.Name</p>
+    <tr class="bg-gray-50">
+        <td colspan="5" class="px-4 py-4">
+            <div class="bg-white rounded-lg p-4 border border-gray-200">
+                <h4 class="font-semibold text-gray-900 mb-2">Подробная информация</h4>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Название:</h5>
+                        <p class="text-gray-600">@Spell.Name</p>
                     </div>
-                    <div class="space-y-1">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Тип</h5>
-                        <p class="text-base font-medium text-gray-900">@Spell.SpellType</p>
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Тип:</h5>
+                        <p class="text-gray-600">@Spell.SpellType</p>
                     </div>
-                    <div class="space-y-1">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Стоимость</h5>
-                        <p class="text-base font-medium text-gray-900">@(!string.IsNullOrWhiteSpace(Spell.Cost) ? Spell.Cost : "—")</p>
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Стоимость:</h5>
+                        <p class="text-gray-600">@(!string.IsNullOrWhiteSpace(Spell.Cost) ? Spell.Cost : "—")</p>
                     </div>
-                    <div class="space-y-1">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Время сотворения</h5>
-                        <p class="text-base font-medium text-gray-900">@(!string.IsNullOrWhiteSpace(Spell.CastingTime) ? Spell.CastingTime : "—")</p>
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Время сотворения:</h5>
+                        <p class="text-gray-600">@(!string.IsNullOrWhiteSpace(Spell.CastingTime) ? Spell.CastingTime : "—")</p>
                     </div>
                 </div>
 
                 @if (Spell.AlternativeNames.Count > 0)
                 {
-                    <div>
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Альтернативные названия</h5>
+                    <div class="mt-4">
+                        <h5 class="font-medium text-gray-700 mb-1">Альтернативные названия:</h5>
                         <div class="flex flex-wrap gap-2">
                             @foreach (var altName in Spell.AlternativeNames)
                             {
-                                <Badge Variant="secondary">
+                                <Badge Variant="secondary" Size="sm" Rounded="md" WithBorder="false">
                                     @altName
                                 </Badge>
                             }
@@ -83,10 +79,13 @@
                     </div>
                 }
 
-                <div>
-                    <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Описание</h5>
-                    <p class="text-base text-gray-700 whitespace-pre-wrap leading-relaxed">@Spell.Description</p>
-                </div>
+                @if (!string.IsNullOrWhiteSpace(Spell.Description))
+                {
+                    <div class="mt-4">
+                        <h5 class="font-medium text-gray-700 mb-1">Описание:</h5>
+                        <p class="text-gray-600 whitespace-pre-wrap">@Spell.Description</p>
+                    </div>
+                }
             </div>
         </td>
     </tr>

--- a/CampaignManager.Web/Components/Features/Spells/Components/SpellsFilterControls.razor
+++ b/CampaignManager.Web/Components/Features/Spells/Components/SpellsFilterControls.razor
@@ -1,21 +1,23 @@
 @namespace CampaignManager.Web.Components.Features.Spells.Components
 
-<div class="flex flex-col lg:flex-row gap-3">
-    <input type="text"
-           value="@SearchQuery"
-           @oninput="HandleSearchInput"
-           placeholder="Поиск заклинаний..."
-           class="flex-1 min-h-[44px] px-4 py-3 border-2 border-gray-300 rounded-lg text-base focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-all" />
+<div class="mb-3">
+    <div class="flex flex-col sm:flex-row gap-2">
+        <input type="text"
+               value="@SearchQuery"
+               @oninput="HandleSearchInput"
+               placeholder="Поиск заклинаний..."
+               class="flex-1 px-3 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-primary-500" />
 
-    <select value="@SelectedTypeFilter"
-            @onchange="HandleSpellTypeChanged"
-            class="lg:w-64 min-h-[44px] px-4 py-3 border-2 border-gray-300 rounded-lg text-base focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-all bg-white">
-        <option value="">Все типы</option>
-        @foreach (var typeValue in SpellTypeOptions)
-        {
-            <option value="@typeValue" selected="@(IsSelected(typeValue))">@typeValue</option>
-        }
-    </select>
+        <select value="@SelectedTypeFilter"
+                @onchange="HandleSpellTypeChanged"
+                class="px-3 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-primary-500">
+            <option value="">Все типы</option>
+            @foreach (var typeValue in SpellTypeOptions)
+            {
+                <option value="@typeValue" selected="@(IsSelected(typeValue))">@typeValue</option>
+            }
+        </select>
+    </div>
 </div>
 
 @code {

--- a/CampaignManager.Web/Components/Features/Spells/Components/SpellsListView.razor
+++ b/CampaignManager.Web/Components/Features/Spells/Components/SpellsListView.razor
@@ -3,11 +3,11 @@
 @using CampaignManager.Web.Components.Shared
 @namespace CampaignManager.Web.Components.Features.Spells.Components
 
-<div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
+<div class="bg-white rounded-lg shadow-md overflow-hidden border border-gray-200">
     <!-- Desktop Table View -->
     <div class="hidden xl:block overflow-x-auto">
-        <table class="w-full text-sm sm:text-base">
-            <thead class="bg-gradient-to-r from-gray-50 to-gray-100 border-b-2 border-gray-200">
+        <table class="w-full text-sm">
+            <thead class="bg-gray-50 border-b border-gray-200">
             <tr>
                 <SortableTableHeader
                     Title="Название"
@@ -37,7 +37,7 @@
                     SortAscending="@SortAscending"
                     OnSortChanged="OnSortChanged" />
 
-                <th class="px-4 sm:px-6 py-4 text-center font-semibold text-gray-700">Действия</th>
+                <th class="px-4 py-3 text-center font-medium text-gray-700">Действия</th>
             </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-100">

--- a/CampaignManager.Web/Components/Features/Spells/Pages/SpellsPage.razor
+++ b/CampaignManager.Web/Components/Features/Spells/Pages/SpellsPage.razor
@@ -10,22 +10,25 @@
 
 <PageTitle>Заклинания - Campaign Manager</PageTitle>
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 font-sans">
+<div class="max-w-7xl mx-auto px-2 py-4 font-sans">
     <FilterPanel Title="Фильтры" @bind-IsExpanded="isSearchPanelVisible">
         <ActionButtons>
             @if (isSearchPanelVisible)
             {
-                <button @onclick="ResetFilters"
-                        class="min-h-[44px] lg:w-64 px-4 py-3 text-primary-600 hover:text-primary-800 bg-primary-50 hover:bg-primary-100 rounded-lg border border-primary-200 hover:border-primary-300 text-base font-medium flex items-center justify-center gap-2 transition-all duration-200">
-                    <i class="fas fa-undo-alt"></i>
-                    <span class="hidden sm:inline">Сбросить</span>
-                </button>
+                <Button OnClick="ResetFilters"
+                        Variant="outline-primary"
+                        Size="sm"
+                        Icon="fa-undo-alt"
+                        AdditionalClasses="text-xs">
+                    Сбросить
+                </Button>
             }
-            <button @onclick="ShowAddModal"
-                    class="min-h-[44px] lg:w-64 px-4 py-3 bg-gradient-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 text-white font-semibold rounded-lg text-base flex items-center justify-center gap-2 shadow-md hover:shadow-lg transition-all duration-200">
-                <i class="fas fa-plus"></i>
-                <span>Добавить</span>
-            </button>
+            <Button OnClick="ShowAddModal"
+                    Variant="info"
+                    Size="sm"
+                    Icon="fa-plus">
+                Добавить
+            </Button>
         </ActionButtons>
         <ChildContent>
             <SpellsFilterControls

--- a/CampaignManager.Web/Components/Features/Weapons/Components/WeaponTableRow.razor
+++ b/CampaignManager.Web/Components/Features/Weapons/Components/WeaponTableRow.razor
@@ -1,132 +1,137 @@
 ﻿@using CampaignManager.Web.Components.Features.Weapons.Model
+@using CampaignManager.Web.Components.Shared
 @using CampaignManager.Web.Extensions
 @namespace CampaignManager.Web.Components.Features.Weapons.Components
 
-<tr class="@(IsExpanded ? "bg-primary-50" : "hover:bg-gray-50") transition-all duration-200 cursor-pointer active:bg-gray-100"
+<tr class="@(IsExpanded ? "bg-gray-50" : "hover:bg-gray-50") transition-colors cursor-pointer"
     @onclick="ToggleExpand">
-    <td class="px-4 sm:px-6 py-4 font-semibold text-gray-900">@Weapon.Name</td>
-    <td class="px-4 sm:px-6 py-4">
-        <Badge Variant="primary">
+    <td class="px-4 py-3 font-medium text-gray-900">@Weapon.Name</td>
+    <td class="px-4 py-3">
+        <Badge Variant="primary" Size="sm" Rounded="md" WithBorder="false">
             @Weapon.Type.ToRussianString()
         </Badge>
     </td>
-    <td class="px-4 sm:px-6 py-4 text-gray-700 font-medium">@Weapon.Skill</td>
-    <td class="px-4 sm:px-6 py-4 text-gray-700 font-medium">@Weapon.Damage</td>
-    <td class="px-4 sm:px-6 py-4">
+    <td class="px-4 py-3 text-gray-700">@Weapon.Skill</td>
+    <td class="px-4 py-3 text-gray-700">@Weapon.Damage</td>
+    <td class="px-4 py-3">
         <div class="flex flex-wrap gap-2">
             @if (Weapon.Is1920)
             {
-                <Badge Variant="secondary">
+                <Badge Variant="secondary" Size="sm" Rounded="md" WithBorder="false">
                     1920s
                 </Badge>
             }
             @if (Weapon.IsModern)
             {
-                <Badge Variant="secondary">
+                <Badge Variant="secondary" Size="sm" Rounded="md" WithBorder="false">
                     Modern
                 </Badge>
             }
         </div>
     </td>
-    <td class="px-4 sm:px-6 py-4 text-gray-600">
-        <div class="text-sm space-y-1.5">
+    <td class="px-4 py-3 text-gray-600">
+        <div class="text-sm space-y-1">
             <div class="flex gap-2">
-                <span class="font-semibold text-gray-700">Дист:</span> 
+                <span class="font-medium text-gray-700">Дист:</span>
                 <span>@Weapon.Range</span>
             </div>
             <div class="flex gap-2">
-                <span class="font-semibold text-gray-700">Атаки:</span> 
+                <span class="font-medium text-gray-700">Атаки:</span>
                 <span>@Weapon.Attacks</span>
             </div>
             @if (!string.IsNullOrEmpty(Weapon.Cost))
             {
                 <div class="flex gap-2">
-                    <span class="font-semibold text-gray-700">Цена:</span> 
+                    <span class="font-medium text-gray-700">Цена:</span>
                     <span>@Weapon.Cost</span>
                 </div>
             }
         </div>
     </td>
-    <td class="px-4 sm:px-6 py-4 text-center" @onclick:stopPropagation="true">
-        <div class="flex flex-col sm:flex-row gap-2 justify-center">
-            <button @onclick="() => OnEdit.InvokeAsync(Weapon)"
-                    class="min-h-[44px] px-4 py-2 text-primary-600 hover:text-primary-800 bg-primary-50 hover:bg-primary-100 rounded-lg text-sm font-semibold flex items-center justify-center gap-2 transition-all duration-200 border border-primary-200">
-                <i class="fas fa-edit"></i>
-                <span>Изменить</span>
-            </button>
-            <button @onclick="() => OnDelete.InvokeAsync(Weapon)"
-                    class="min-h-[44px] px-4 py-2 text-error-600 hover:text-error-800 bg-error-50 hover:bg-error-100 rounded-lg text-sm font-semibold flex items-center justify-center gap-2 transition-all duration-200 border border-error-200">
-                <i class="fas fa-trash-alt"></i>
-                <span>Удалить</span>
-            </button>
+    <td class="px-4 py-3 text-center" @onclick:stopPropagation="true">
+        <div class="flex gap-1 justify-center">
+            <Button OnClick="() => OnEdit.InvokeAsync(Weapon)"
+                    Variant="outline-primary"
+                    Size="sm"
+                    Icon="fa-edit"
+                    AdditionalClasses="text-xs shadow-none border-0">
+                Изменить
+            </Button>
+            <Button OnClick="() => OnDelete.InvokeAsync(Weapon)"
+                    Variant="outline-error"
+                    Size="sm"
+                    Icon="fa-trash-alt"
+                    AdditionalClasses="text-xs shadow-none border-0">
+                Удалить
+            </Button>
         </div>
     </td>
 </tr>
 
 @if (IsExpanded)
 {
-    <tr class="bg-gradient-to-r from-gray-50 to-white border-t-2 border-primary-200">
-        <td colspan="7" class="px-4 sm:px-6 py-6">
-            <div class="bg-white rounded-xl p-6 shadow-inner border-2 border-gray-100">
-                <h4 class="text-lg font-bold text-gray-900 mb-4 pb-2 border-b-2 border-primary-200">Подробная информация</h4>
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                    <div class="space-y-1">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Название</h5>
-                        <p class="text-base font-medium text-gray-900">@Weapon.Name</p>
+    <tr class="bg-gray-50">
+        <td colspan="7" class="px-4 py-4">
+            <div class="bg-white rounded-lg p-4 border border-gray-200">
+                <h4 class="font-semibold text-gray-900 mb-2">Подробная информация</h4>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Название:</h5>
+                        <p class="text-gray-600">@Weapon.Name</p>
                     </div>
-                    <div class="space-y-1">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Тип</h5>
-                        <p class="text-base font-medium text-gray-900">@Weapon.Type.ToRussianString()</p>
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Тип:</h5>
+                        <p class="text-gray-600">@Weapon.Type.ToRussianString()</p>
                     </div>
-                    <div class="space-y-1">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Навык</h5>
-                        <p class="text-base font-medium text-gray-900">@Weapon.Skill</p>
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Навык:</h5>
+                        <p class="text-gray-600">@Weapon.Skill</p>
                     </div>
-                    <div class="space-y-1">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Урон</h5>
-                        <p class="text-base font-medium text-gray-900">@Weapon.Damage</p>
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Урон:</h5>
+                        <p class="text-gray-600">@Weapon.Damage</p>
                     </div>
-                    <div class="space-y-1">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Дальность</h5>
-                        <p class="text-base font-medium text-gray-900">@Weapon.Range</p>
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Дальность:</h5>
+                        <p class="text-gray-600">@Weapon.Range</p>
                     </div>
-                    <div class="space-y-1">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Атаки</h5>
-                        <p class="text-base font-medium text-gray-900">@Weapon.Attacks</p>
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Атаки:</h5>
+                        <p class="text-gray-600">@Weapon.Attacks</p>
                     </div>
                     @if (!string.IsNullOrEmpty(Weapon.Cost))
                     {
-                        <div class="space-y-1">
-                            <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Стоимость</h5>
-                            <p class="text-base font-medium text-gray-900">@Weapon.Cost</p>
+                        <div>
+                            <h5 class="font-medium text-gray-700 mb-1">Стоимость:</h5>
+                            <p class="text-gray-600">@Weapon.Cost</p>
                         </div>
                     }
                     @if (!string.IsNullOrEmpty(Weapon.Ammo))
                     {
-                        <div class="space-y-1">
-                            <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Боеприпасы</h5>
-                            <p class="text-base font-medium text-gray-900">@Weapon.Ammo</p>
+                        <div>
+                            <h5 class="font-medium text-gray-700 mb-1">Боеприпасы:</h5>
+                            <p class="text-gray-600">@Weapon.Ammo</p>
                         </div>
                     }
                     @if (!string.IsNullOrEmpty(Weapon.Malfunction))
                     {
-                        <div class="space-y-1">
-                            <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Осечка</h5>
-                            <p class="text-base font-medium text-gray-900">@Weapon.Malfunction</p>
+                        <div>
+                            <h5 class="font-medium text-gray-700 mb-1">Осечка:</h5>
+                            <p class="text-gray-600">@Weapon.Malfunction</p>
                         </div>
                     }
-                    <div class="space-y-2">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide">Эпоха</h5>
+                    <div>
+                        <h5 class="font-medium text-gray-700 mb-1">Эпоха:</h5>
                         <div class="flex flex-wrap gap-2">
                             @if (Weapon.Is1920)
                             {
-                                <Badge Variant="secondary">
+                                <Badge Variant="secondary" Size="sm" Rounded="md" WithBorder="false">
                                     1920s
                                 </Badge>
                             }
                             @if (Weapon.IsModern)
                             {
-                                <Badge Variant="secondary">
+                                <Badge Variant="secondary" Size="sm" Rounded="md" WithBorder="false">
                                     Modern
                                 </Badge>
                             }
@@ -135,9 +140,9 @@
                 </div>
                 @if (!string.IsNullOrEmpty(Weapon.Notes))
                 {
-                    <div class="mt-6 pt-4 border-t-2 border-gray-100">
-                        <h5 class="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">Примечания</h5>
-                        <p class="text-base text-gray-700 whitespace-pre-wrap leading-relaxed">@Weapon.Notes</p>
+                    <div class="mt-4">
+                        <h5 class="font-medium text-gray-700 mb-1">Примечания:</h5>
+                        <p class="text-gray-600 whitespace-pre-wrap">@Weapon.Notes</p>
                     </div>
                 }
             </div>

--- a/CampaignManager.Web/Components/Features/Weapons/Components/WeaponsFilterControls.razor
+++ b/CampaignManager.Web/Components/Features/Weapons/Components/WeaponsFilterControls.razor
@@ -2,40 +2,44 @@
 @using CampaignManager.Web.Extensions
 @namespace CampaignManager.Web.Components.Features.Weapons.Components
 
-<div class="flex flex-col lg:flex-row gap-3">
-    <input type="text"
-           value="@SearchQuery"
-           @oninput="HandleSearchInput"
-           placeholder="Поиск оружия..."
-           class="flex-1 min-h-[44px] px-4 py-3 border-2 border-gray-300 rounded-lg text-base focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-all" />
+<div class="mb-3">
+    <div class="flex flex-col sm:flex-row gap-2">
+        <input type="text"
+               value="@SearchQuery"
+               @oninput="HandleSearchInput"
+               placeholder="Поиск оружия..."
+               class="flex-1 px-3 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-primary-500" />
 
-    <select @onchange="HandleWeaponTypeChanged"
-            class="lg:w-64 min-h-[44px] px-4 py-3 border-2 border-gray-300 rounded-lg text-base focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-all bg-white">
-        <option value="">Все типы</option>
-        @foreach (var typeValue in EnumExtensions.GetWeaponTypes())
-        {
-            <option value="@typeValue" selected="@(SelectedTypeFilter == typeValue)">@typeValue.ToRussianString()</option>
-        }
-    </select>
+        <select @onchange="HandleWeaponTypeChanged"
+                class="px-3 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-primary-500">
+            <option value="">Все типы</option>
+            @foreach (var typeValue in EnumExtensions.GetWeaponTypes())
+            {
+                <option value="@typeValue" selected="@(SelectedTypeFilter == typeValue)">@typeValue.ToRussianString()</option>
+            }
+        </select>
+    </div>
 </div>
 
-<!-- Era Filters - Touch Optimized -->
-<div class="flex flex-wrap items-center gap-4 sm:gap-6 p-3 bg-gray-50 rounded-lg mt-3">
-    <span class="text-sm font-semibold text-gray-700">Эпоха:</span>
-    <label class="flex items-center gap-3 cursor-pointer group min-h-[44px]">
-        <input type="checkbox"
-               checked="@Is1920Filter"
-               @onchange="async e => await UpdateBoolAsync(Is1920FilterChanged, e)"
-               class="w-5 h-5 text-primary-600 focus:ring-2 focus:ring-primary-500 border-gray-300 rounded cursor-pointer" />
-        <span class="text-base font-medium text-gray-700 group-hover:text-primary-600 transition-colors">1920s</span>
-    </label>
-    <label class="flex items-center gap-3 cursor-pointer group min-h-[44px]">
-        <input type="checkbox"
-               checked="@IsModernFilter"
-               @onchange="async e => await UpdateBoolAsync(IsModernFilterChanged, e)"
-               class="w-5 h-5 text-primary-600 focus:ring-2 focus:ring-primary-500 border-gray-300 rounded cursor-pointer" />
-        <span class="text-base font-medium text-gray-700 group-hover:text-primary-600 transition-colors">Modern</span>
-    </label>
+<div class="flex flex-wrap justify-between items-center gap-2 mb-1">
+    <div class="flex flex-wrap items-center gap-3 sm:gap-4">
+        <div class="flex items-center">
+            <input type="checkbox"
+                   id="era1920-weapons"
+                   checked="@Is1920Filter"
+                   @onchange="async e => await UpdateBoolAsync(Is1920FilterChanged, e)"
+                   class="mr-1 h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded" />
+            <label for="era1920-weapons" class="text-sm text-gray-700">1920s</label>
+        </div>
+        <div class="flex items-center">
+            <input type="checkbox"
+                   id="eraModern-weapons"
+                   checked="@IsModernFilter"
+                   @onchange="async e => await UpdateBoolAsync(IsModernFilterChanged, e)"
+                   class="mr-1 h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded" />
+            <label for="eraModern-weapons" class="text-sm text-gray-700">Modern</label>
+        </div>
+    </div>
 </div>
 
 @code {

--- a/CampaignManager.Web/Components/Features/Weapons/Components/WeaponsListView.razor
+++ b/CampaignManager.Web/Components/Features/Weapons/Components/WeaponsListView.razor
@@ -4,11 +4,11 @@
 @using CampaignManager.Web.Extensions
 @namespace CampaignManager.Web.Components.Features.Weapons.Components
 
-<div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
+<div class="bg-white rounded-lg shadow-md overflow-hidden border border-gray-200">
     <!-- Desktop Table View - Hidden on tablet/mobile; show only on xl+ -->
     <div class="hidden xl:block overflow-x-auto">
-        <table class="w-full text-sm sm:text-base">
-            <thead class="bg-gradient-to-r from-gray-50 to-gray-100 border-b-2 border-gray-200">
+        <table class="w-full text-sm">
+            <thead class="bg-gray-50 border-b border-gray-200">
             <tr>
                 <SortableTableHeader 
                     Title="Название" 
@@ -45,8 +45,8 @@
                     SortAscending="@SortAscending"
                     OnSortChanged="OnSortChanged" />
                 
-                <th class="px-4 sm:px-6 py-4 text-left font-semibold text-gray-700">Характеристики</th>
-                <th class="px-4 sm:px-6 py-4 text-center font-semibold text-gray-700">Действия</th>
+                <th class="px-4 py-3 text-left font-medium text-gray-700">Характеристики</th>
+                <th class="px-4 py-3 text-center font-medium text-gray-700">Действия</th>
             </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-100">

--- a/CampaignManager.Web/Components/Features/Weapons/Pages/WeaponsPage.razor
+++ b/CampaignManager.Web/Components/Features/Weapons/Pages/WeaponsPage.razor
@@ -13,23 +13,26 @@
 
 <PageTitle>Оружие - Campaign Manager</PageTitle>
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 font-sans">
+<div class="max-w-7xl mx-auto px-2 py-4 font-sans">
     <!-- Filter Panel -->
     <FilterPanel Title="Фильтры" @bind-IsExpanded="isSearchPanelVisible">
         <ActionButtons>
             @if (isSearchPanelVisible)
             {
-                <button @onclick="ResetFilters"
-                        class="min-h-[44px] lg:w-64 px-4 py-3 text-primary-600 hover:text-primary-800 bg-primary-50 hover:bg-primary-100 rounded-lg border border-primary-200 hover:border-primary-300 text-base font-medium flex items-center justify-center gap-2 transition-all duration-200">
-                    <i class="fas fa-undo-alt"></i>
-                    <span class="hidden sm:inline">Сбросить</span>
-                </button>
+                <Button OnClick="ResetFilters"
+                        Variant="outline-primary"
+                        Size="sm"
+                        Icon="fa-undo-alt"
+                        AdditionalClasses="text-xs">
+                    Сбросить
+                </Button>
             }
-            <button @onclick="ShowAddModal"
-                    class="min-h-[44px] lg:w-64 px-4 py-3 bg-gradient-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 text-white font-semibold rounded-lg text-base flex items-center justify-center gap-2 shadow-md hover:shadow-lg transition-all duration-200">
-                <i class="fas fa-plus"></i>
-                <span>Добавить</span>
-            </button>
+            <Button OnClick="ShowAddModal"
+                    Variant="info"
+                    Size="sm"
+                    Icon="fa-plus">
+                Добавить
+            </Button>
         </ActionButtons>
         <ChildContent>
             <WeaponsFilterControls

--- a/CampaignManager.Web/Components/Shared/FilterPanel.razor
+++ b/CampaignManager.Web/Components/Shared/FilterPanel.razor
@@ -1,24 +1,22 @@
 ﻿@namespace CampaignManager.Web.Components.Shared
 
-<div class="sticky top-0 z-10 bg-white rounded-xl shadow-lg p-4 sm:p-5 mb-6 border border-gray-200 backdrop-blur-sm bg-white/95">
-    <div class="flex justify-between items-center mb-3">
-        <div class="flex items-center gap-3">
-            <h2 class="text-lg sm:text-xl font-bold text-gray-800">@Title</h2>
-            <button @onclick="TogglePanel" 
-                    class="min-w-[44px] min-h-[44px] flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200">
-                <i class="fas @(IsExpanded ? "fa-chevron-up" : "fa-chevron-down") text-lg"></i>
+<div class="sticky top-0 z-10 bg-white rounded-lg shadow-md p-3 mb-4 border border-gray-200">
+    <div class="flex justify-between items-center mb-2">
+        <div class="flex items-center">
+            <h2 class="text-base font-semibold text-gray-700 mr-2">@Title</h2>
+            <button @onclick="TogglePanel"
+                    class="text-gray-500 hover:text-gray-700 transition-colors">
+                <i class="fas @(IsExpanded ? "fa-chevron-up" : "fa-chevron-down")"></i>
             </button>
         </div>
-        <div class="flex gap-2 sm:gap-3">
+        <div class="flex space-x-2">
             @ActionButtons
         </div>
     </div>
 
     @if (IsExpanded)
     {
-        <div class="space-y-4">
-            @ChildContent
-        </div>
+        @ChildContent
     }
 </div>
 


### PR DESCRIPTION
Updated weapons and spells pages to match the cleaner, more compact design of the items page:

- Simplified table styling (shadow-md instead of shadow-lg, removed gradients)
- Made table headers more compact (px-4 py-3 instead of px-4 sm:px-6 py-4)
- Replaced large custom buttons with compact Button components (size="sm")
- Updated action buttons to use outline variants with minimal shadows
- Simplified expanded details sections with cleaner borders and spacing
- Reduced padding throughout for a more minimalist appearance
- Updated filter panel buttons to use compact Button components
- Changed container padding from px-4 sm:px-6 lg:px-8 py-6 to px-2 py-4

All changes maintain responsive behavior while providing a cleaner, more consistent user experience.